### PR TITLE
refactor(cuid2): leverage markrogoyski/math-php when GMP extension is unavailable

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,12 +17,12 @@ A PHP implementation of collision-resistant ids. You can read more about CUIDs f
 
 You can install visus/cuid2 as a [composer package](https://packagist.org/packages/visus/cuid2):
 
-> [!IMPORTANT]
-> The PHP extension [GMP](https://www.php.net/manual/en/intro.gmp.php) is required in order to use this library.
-
 ```shell
 composer require visus/cuid2
 ```
+> [!TIP]
+> Consider installing/enabling the PHP extension [GMP](https://www.php.net/manual/en/intro.gmp.php).
+> If this is not an option then [markrogoyski/math-php](https://github.com/markrogoyski/math-php) will be used as a fallback.
 
 ## Quick Example
 

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     ],
     "require": {
         "php": "^8.1",
-        "ext-gmp": "*",
+        "markrogoyski/math-php": "^2.11",
         "symfony/polyfill-php83": "^1.32"
     },
     "require-dev": {
@@ -28,6 +28,9 @@
         "ramsey/conventional-commits": "^1.5",
         "squizlabs/php_codesniffer": "^3.7",
         "vimeo/psalm": "^6.0"
+    },
+    "suggest": {
+        "ext-gmp": "Allows for quicker Base16 to Base36 conversion"
     },
     "minimum-stability": "dev",
     "prefer-stable": true,

--- a/src/InvalidOperationException.php
+++ b/src/InvalidOperationException.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Visus\Cuid2;
+
+use Exception;
+
+/**
+ * Exception that is thrown when a method call is invalid for the object's current state.
+ */
+final class InvalidOperationException extends Exception
+{
+}


### PR DESCRIPTION
# Description

This pull request is a revisitation for the issue #255 where `base_convert` could not handle large arbitrary numbers. The quick fix solution was to make the PHP extension [GMP](https://www.php.net/manual/en/intro.gmp.php) required rather than optional as the suggested library in the issue had an incompatible license.

Having a hard dependency on an extension that may not be present in all environments was not really diserable long-term but fortunately the [markrogoyski/math-php](https://github.com/markrogoyski/math-php) project has provided a working solution that is license compatible and allows for returning of the `GMP` extension to an optional state than being required.