### PR TITLE
feat: add isValid method for basic validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ composer require visus/cuid2
 > Consider installing/enabling the PHP extension [GMP](https://www.php.net/manual/en/intro.gmp.php).
 > If this is not an option then [markrogoyski/math-php](https://github.com/markrogoyski/math-php) will be used as a fallback.
 
-## Quick Example
+## Examples
 
 ### Instance Based
 
@@ -63,4 +63,15 @@ echo $cuid->toString(); // apr5hhh4ox45krsg9gycbs9k
 // new (with custom length)
 $cuid = Visus\Cuid2\Cuid2::generate(10);
 echo $cuid; // pekw02xwsd
+```
+### Validation
+
+```php
+<?php
+require_once 'vendor/autoload.php';
+
+Cuid2::isValid('apr5hhh4ox45krsg9gycbs9k'); // true
+Cuid2::isValid('invalid-cuid'); // false
+Cuid2::isValid('pekw02xwsd', expectedLength: 10); // true
+
 ```

--- a/src/Cuid2.php
+++ b/src/Cuid2.php
@@ -78,6 +78,15 @@ final class Cuid2 implements JsonSerializable
         return new self($maxLength);
     }
 
+    public static function isValid(string $id, ?int $expectedLength = null): bool
+    {
+        if ($expectedLength !== null && (strlen($id) < 4 || strlen($id) > 32 || strlen($id) !== $expectedLength)) {
+            return false;
+        }
+
+        return preg_match('/^[a-z][a-z0-9]{3,31}$/', $id) === 1;
+    }
+
     /**
      * @throws Exception
      */


### PR DESCRIPTION
- Closes #271 

# Description

Implements a `Cuid2::isValid` method for basic validation that the given string is a Cuid2. It however does not guarantee that the value is actually a Cuid.